### PR TITLE
Added support for custom HTTP verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ The webserver comes with some predefined response status codes for certain paths
 | /service-unavailable    | 503           |
 | /gateway-timeout        | 504           |
 
+### Custom HTTP verbs
+
+    $ docker run -d -p 80:80 -e 'allow_http_verbs=FOO,BAR' campanda/webserver-mock
+    // or you can with -it instead to check the logs
+
+By default only `GET` and `POST` are allowed.
+
+    $ curl -i http://localhost/ -X FOO
+    HTTP/1.1 200 OK
+    ...
+
+    $ curl -i http://localhost/ -X BAR
+    HTTP/1.1 200 OK
+    ...
+
+    $ curl -i http://localhost/ -X BACON
+    HTTP/1.1 405 Method Not Allowed
+    ...
+
 ## License
 
 webserver-mock is released under the [MIT License][0].

--- a/tests/custom_http_verbs_tests.sh
+++ b/tests/custom_http_verbs_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function test_server_replies_with_200_for_allowed_http_verbs {
+  foo=$(curl -sI http://target-with-custom-http-verbs/ -X FOO)
+  bar=$(curl -sI http://target-with-custom-http-verbs/ -X BAR)
+  echo "$foo" | grep -q '200 OK' &&\
+  echo "$bar" | grep -q '200 OK'
+}
+
+function test_server_replies_with_405_for_not_allowed_http_verbs {
+  actual=$(curl -sI http://target-with-custom-http-verbs/ -X BACON)
+  echo "$actual" | grep -q '405 Method Not Allowed'
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     environment:
       - 'ssl=true'
 
+  target-with-custom-http-verbs:
+    build: ..
+    environment:
+      - 'allow_http_verbs=FOO,BAR'
+
   tests:
     build: .
     volumes:

--- a/webserver.rb
+++ b/webserver.rb
@@ -13,6 +13,19 @@ end
 
 require 'webrick'
 
+if ENV['allow_http_verbs']
+  module WEBrick
+    module HTTPServlet
+      # Allowing server to respond to requests using custom HTTP verbs
+      class ProcHandler
+        ENV['allow_http_verbs'].split(',').each do |verb|
+          alias_method "do_#{verb}", 'do_GET'
+        end
+      end
+    end
+  end
+end
+
 if ENV['ssl']
   require 'webrick/https'
   opts = { Port: 443, SSLEnable: true, SSLCertName: [%w(CN localhost)] }


### PR DESCRIPTION
By default WEBrick only allows `GET` and `POST`.